### PR TITLE
Clarify 'Deep Agents Code' description

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -33,7 +33,7 @@ Commercial Platform:
 
 OSS extensions and apps:
 
-- [`Deep Agents Code`](https://docs.langchain.com/oss/python/deepagents/code/overview) - open source coding agent in your terminal, similar to Claude Code or Cursor, powered by any LLM
+- [`Deep Agents Code`](https://docs.langchain.com/oss/python/deepagents/code/overview) - `dcode` is an open source coding agent in your terminal, similar to Claude Code or Cursor, powered by any LLM
 - [`Open SWE`](https://github.com/langchain-ai/open-swe) – open source asynchronous coding agent
 - [`MCP Adapters`](https://github.com/langchain-ai/langchain-mcp-adapters) – make MCP tools compatible with LangChain and LangGraph
 - [`Agent Protocol`](https://github.com/langchain-ai/agent-protocol) – our attempt at codifying the framework-agnostic APIs that are needed to serve LLM agents in production


### PR DESCRIPTION
Updated description of 'Deep Agents Code' to include its command name 'dcode'.